### PR TITLE
fix: mark HypixelPacketHandler as Sharable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     repositories {
         maven {
             name = "forge"
-            url = "http://files.minecraftforge.net/maven"
+            url = "https://files.minecraftforge.net/maven"
         }
     }
     dependencies {

--- a/src/main/java/net/hypixel/modapi/forge/ForgeModAPI.java
+++ b/src/main/java/net/hypixel/modapi/forge/ForgeModAPI.java
@@ -51,6 +51,7 @@ public class ForgeModAPI {
         return true;
     }
 
+    @ChannelHandler.Sharable
     private static class HypixelPacketHandler extends SimpleChannelInboundHandler<Packet<?>> {
         private static final HypixelPacketHandler INSTANCE = new HypixelPacketHandler();
 


### PR DESCRIPTION
Using the Sharable annotation allows the use of the PacketHandler as a singleton