### PR TITLE
Various build script improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,12 @@ This repository contains the implementation of the Hypixel Mod API for the Froge
 ## Contributing
 
 If you wish to contribute to this implementation of the Mod API to offer improvements or fixes, you can do so by forking the repository and creating a pull request.
+
+> [!IMPORTANT]  
+> Run `gradlew setupDecompWorkspace` after importing the project to generate the files required to build it
+
+If IntelliJ still shows unknown symbol errors after running the command, you may need to [clear the filesystem cache](https://www.jetbrains.com/help/idea/invalidate-caches.html).
+
+### Testing Your Changes
+
+You can enable DevAuth to log in to the Hypixel server with your Minecraft account. Please see the [DevAuth docs](https://github.com/DJtheRedstoner/DevAuth) for more details.

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,9 @@ repositories {
     maven {
         url "https://repo.hypixel.net/repository/Hypixel/"
     }
+    maven {
+        url "https://pkgs.dev.azure.com/djtheredstoner/DevAuth/_packaging/public/maven/v1"
+    }
     mavenLocal()
 }
 
@@ -31,6 +34,9 @@ minecraft {
     runDir = "run"
 
     mappings = "stable_22"
+
+    replace('${version}', project.version)
+    replaceIn("ForgeModAPI.java")
 }
 
 configurations {
@@ -40,6 +46,7 @@ configurations {
 
 dependencies {
     shade "net.hypixel:mod-api:1.0"
+    runtimeOnly "me.djtheredstoner:DevAuth-forge-legacy:1.2.1"
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+# Ensure Gradle has enough RAM to decompile Minecraft
+org.gradle.jvmargs=-Xmx2G

--- a/src/main/java/net/hypixel/modapi/forge/ForgeModAPI.java
+++ b/src/main/java/net/hypixel/modapi/forge/ForgeModAPI.java
@@ -20,14 +20,14 @@ import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.network.FMLNetworkEvent;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 @Mod(modid = ForgeModAPI.MODID, version = ForgeModAPI.VERSION, clientSideOnly = true, name = "Hypixel Mod API")
 public class ForgeModAPI {
     public static final String MODID = "hypixel_mod_api";
-    public static final String VERSION = "1.0.0.1";
-    private static final Logger LOGGER = Logger.getLogger("HypixelModAPI");
+    public static final String VERSION = "${version}";
+    private static final Logger LOGGER = LogManager.getLogger("HypixelModAPI");
 
     // We store a local reference to the net handler, so it's instantly available from the moment we connect
     private NetHandlerPlayClient netHandler;
@@ -36,6 +36,7 @@ public class ForgeModAPI {
     public void init(FMLPostInitializationEvent event) {
         MinecraftForge.EVENT_BUS.register(this);
         HypixelModAPI.getInstance().setPacketSender(this::sendPacket);
+        LOGGER.debug("Hypixel Mod API initialized");
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
@@ -55,7 +56,7 @@ public class ForgeModAPI {
         }
 
         if (!netHandler.getNetworkManager().isChannelOpen()) {
-            LOGGER.warning("Attempted to send packet while channel is closed!");
+            LOGGER.warn("Attempted to send packet while channel is closed!");
             netHandler = null;
             return false;
         }
@@ -91,7 +92,7 @@ public class ForgeModAPI {
                 try {
                     HypixelModAPI.getInstance().handle(identifier, new PacketSerializer(buffer));
                 } catch (Exception e) {
-                    LOGGER.log(Level.WARNING, "Failed to handle packet " + identifier, e);
+                    LOGGER.warn("Failed to handle packet {}", identifier, e);
                 } finally {
                     buffer.release();
                 }

--- a/src/main/java/net/hypixel/modapi/forge/ForgeModAPI.java
+++ b/src/main/java/net/hypixel/modapi/forge/ForgeModAPI.java
@@ -36,7 +36,6 @@ public class ForgeModAPI {
     public void init(FMLPostInitializationEvent event) {
         MinecraftForge.EVENT_BUS.register(this);
         HypixelModAPI.getInstance().setPacketSender(this::sendPacket);
-        LOGGER.debug("Hypixel Mod API initialized");
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)


### PR DESCRIPTION
- Add DevAuth for logging into online mode servers (disabled by default)
- Fill in mod version during build in ForgeModAPI.java
- Fix gradle running out of memory during `gradlew setupDecompWorkspace`
- Add some development tips to README.md
- Change logging to log4j in ForgeModAPI.java